### PR TITLE
Typo in the Github handle mentionned in `opam` file

### DIFF
--- a/ppx_matches.opam
+++ b/ppx_matches.opam
@@ -6,8 +6,8 @@ Translates [%matches? <PATTERN>] into (function | <PATTERN> -> true | _ -> false
 maintainer: "Will Robson <will at will robson dot uk>"
 authors: "Will Robson <will at will robson dot uk>"
 license: "MIT"
-homepage: "https://github.com/wrbx/ppx_matches"
-bug-reports: "https://github.com/wrbx/ppx_matches/issues"
+homepage: "https://github.com/wrbs/ppx_matches"
+bug-reports: "https://github.com/wrbs/ppx_matches/issues"
 dev-repo: "git://github.com/wrbs/ppx_matches"
 depends: [
   "ocaml" {>= "4.04"}


### PR DESCRIPTION
Hi,

Thanks for your PPX, that's exactly what I was looking for!

This PR just fixes a small typo in your Github handle in the `opam` file.
Currently, the link to your Github repository on ocaml.org is broken (https://ocaml.org/p/ppx_matches/0.1 links to https://github.com/wrbx/ppx_matches instead of https://github.com/wrbs/ppx_matches).